### PR TITLE
Add RiderLink to gitignore

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -76,3 +76,5 @@ Plugins/**/Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*
+
+Plugins/Developer/RiderLink/*


### PR DESCRIPTION
RiderLink is a plugin that allows advanced integration between Rider and the engine, but it doesn't need to belong inside the repo. Thus, it is added to the gitignore.